### PR TITLE
Fix caching deprecation warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,10 @@ module.exports = {
   setupPreprocessorRegistry(type, registry) {
     registry.add('htmlbars-ast-plugin', {
       name: 'ember-maybe-in-element-transform',
-      plugin: EmberMaybeInElementAstTransform
+      plugin: EmberMaybeInElementAstTransform,
+      baseDir() {
+        return __dirname;
+      }
     });
   },
 };


### PR DESCRIPTION
Fixes...
```
DEPRECATION: ember-cli-htmlbars-inline-precompile is opting out of caching due to an AST plugin that does not provide a caching strategy: `ember-maybe-in-element-transform`.
DEPRECATION: ember-cli-htmlbars is opting out of caching due to an AST plugin that does not provide a caching strategy: `ember-maybe-in-element-transform`.
```

See for example https://github.com/offirgolan/ember-cp-validations/pull/305