### PR TITLE
Refactor transform to work with Ember 1.13

### DIFF
--- a/lib/ast-transform.js
+++ b/lib/ast-transform.js
@@ -28,28 +28,27 @@ module.exports = class EmberMaybeInElementAstTransform {
   }
 
   transform(ast) {
-    const b = this.syntax.builders;
-    this.syntax.traverse(ast, {
-      BlockStatement(node) {
-        if (node.path.original === 'maybe-in-element') {
-          if (node.params.length < 2) {
-            throw new Error('{{#maybe-in-element}} requires two arguments. The first is the destination element and the second is the `renderInPlace` boolean flag');
-          }
-          return b.block(
-            b.path('if'),
-            [node.params[1]],
-            undefined,
-            node.program,
-            b.program([
-              b.block(
-                b.path('-in-element'),
-                [node.params[0]],
-                undefined,
-                deepClone(node.program)
-              )
-            ])
-          );
+    let walker = new this.syntax.Walker();
+
+    let b = this.syntax.builders;
+
+    walker.visit(ast, function(node) {
+      if (node.type === 'BlockStatement' && node.path.original === 'maybe-in-element') {
+        if (node.params.length < 2) {
+          throw new Error('{{#maybe-in-element}} requires two arguments. The first is the destination element and the second is the `renderInPlace` boolean flag');
         }
+        let destinationElement = node.params[0];
+        let renderInPlace = node.params[1];
+        node.path = b.path('if');
+        node.params = [renderInPlace];
+        node.inverse = b.program([
+          b.block(
+            b.path('-in-element'),
+            [destinationElement],
+            undefined,
+            deepClone(node.program)
+          )
+        ]);
       }
     });
 


### PR DESCRIPTION
Unfortunately `syntax.traverse` does not work in Ember 1.13. Although this addon does not support anything pre Glimmer2, when used together with `ember-in-element-polyfill` it allows for backwards compatibility all down to Ember 1.13 (the minimum version ember-wormhole supports). 

This is currently not possible, as the transform will break the build for Ember 1.13. Though the transform looks a bit more ugly now, I think it would be cool if both addons play nicely together. 