### PR TITLE
Add dirty workaround for AST plugins in wrong order

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,12 +6,27 @@ module.exports = {
   name: require('./package').name,
 
   setupPreprocessorRegistry(type, registry) {
-    registry.add('htmlbars-ast-plugin', {
+    let plugins = registry.load('htmlbars-ast-plugin');
+    let inElementPlugin = plugins.find((plugin) => plugin.name === 'ember-in-element-polyfill');
+    let maybePlugin = {
       name: 'ember-maybe-in-element-transform',
       plugin: EmberMaybeInElementAstTransform,
       baseDir() {
         return __dirname;
       }
-    });
+    };
+
+    // Yes, this a bit ugly, but it seems for some reason AST plugins are applied in a different order (reversed?) than
+    // the order they are added to the registry.
+    // With this dirty hack we make sure there is always a "polyfill" transform running after the "maybe" transform, to make
+    // sure the AST returned from "maybe" containing `{{in-element}}` gets further transformed by the polyfill!
+    if (inElementPlugin) {
+      registry.remove('htmlbars-ast-plugin', inElementPlugin);
+      registry.add('htmlbars-ast-plugin', inElementPlugin);
+      registry.add('htmlbars-ast-plugin', maybePlugin);
+      registry.add('htmlbars-ast-plugin', inElementPlugin);
+    } else {
+      registry.add('htmlbars-ast-plugin', maybePlugin);
+    }
   },
 };

--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",
-    "before": "ember-in-element-polyfill"
+    "after": "ember-in-element-polyfill"
   }
 }


### PR DESCRIPTION
@cibernox As I wanted to update to the latest `ember-in-element-polyfill`, but without having to migrate away from `ember-maybe-in-element`, I took a look at the failing issue in #15 we talked about a while ago.

I remembered that I had to do some trickery regarding the order of AST plugins for an older version of the polyfill, where it had some explicit support for `ember-maybe-in-element`: https://github.com/kaliber5/ember-in-element-polyfill/blob/9aeec71d12dd6db9586097ffc11f94d30d6120cb/index.js

Applying the same tricks here seems to fix the issue!

And I certainly agree that this look ugly as hell, sorry about that! 😬