### PR TITLE
Add baseDir to babel plugin to allow caching

### DIFF
--- a/lib/ast-transform.js
+++ b/lib/ast-transform.js
@@ -19,7 +19,7 @@
  * It also thrown an error if called with less than two arguments.
  */
 module.exports = function(is317OrGreater) {
-  return function ({ syntax }) {
+  function emberMaybeInElementAstTransform ({ syntax }) {
     const b = syntax.builders;
 
     let buildMaybeInElement;
@@ -67,4 +67,8 @@ module.exports = function(is317OrGreater) {
       },
     };
   }
+
+  emberMaybeInElementAstTransform.baseDir = function() { return __dirname; };
+
+  return emberMaybeInElementAstTransform;
 };


### PR DESCRIPTION
The build under embroider complained that this plugin prevented proper caching. I've tried it in our app and defining the `baseDir` made the warning go away.